### PR TITLE
use github keyword in dependencies

### DIFF
--- a/dependencies.txt
+++ b/dependencies.txt
@@ -1,1 +1,1 @@
-https://github.com/Ezandora/Choice-Override/branches/Release/
+github Ezandora/Choice-Override Release


### PR DESCRIPTION
github is removing SVN support on Jan 8, 2024
KoLmafia can install scripts via GIT.

dependencies.txt can have "github" syntax which will look for either SVN or GIT installation and will install via GIT if not yet installed.
